### PR TITLE
Fix typo in URL for Products link

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -32,7 +32,7 @@ const Footer = () => {
                                     <HashLink to="/" className="text-[#013289] hover:text-gray-900 hover:tracking-wider transition duration-250 ease-in-out">Home</HashLink>
                                 </li>
                                 <li className="mb-2">
-                                    <HashLink to="#" className="text-[#013289] hover:text-gray-900 hover:tracking-wider transition duration-250 ease-in-out">Products</HashLink>
+                                    <HashLink to="/nobilipk#products" className="text-[#013289] hover:text-gray-900 hover:tracking-wider transition duration-250 ease-in-out">Products</HashLink>
                                 </li>
                                 <li className="mb-2">
                                     <HashLink to="#" className="text-[#013289] hover:text-gray-900 hover:tracking-wider transition duration-250 ease-in-out">Contact</HashLink>

--- a/src/components/Navbar/NavLinks.js
+++ b/src/components/Navbar/NavLinks.js
@@ -7,7 +7,7 @@ const NavLinks = () => {
             <HashLink className="px-4 font-extrabold text-gray-500 hover:text-blue-900" to="/">
                 Home
             </HashLink>
-            <HashLink className="px-4 font-extrabold text-gray-500 hover:text-blue-900" smooth to="/nobilipk#services">
+            <HashLink className="px-4 font-extrabold text-gray-500 hover:text-blue-900" smooth to="/nobilipk#products">
                 Products
             </HashLink>
             <HashLink className="px-4 font-extrabold text-gray-500 hover:text-blue-900" smooth to="/nobilipk#about">


### PR DESCRIPTION
Fix typo in URL for "Products" item in navigation bar and footer.

* Change the `to` prop of the "Products" `HashLink` in `src/components/Navbar/NavLinks.js` to `"/nobilipk#products"`
* Change the `to` prop of the "Products" `HashLink` in `src/components/Footer.js` to `"/nobilipk#products"`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/naveed949/nobilipk?shareId=55d4f885-0298-49b5-8589-f5565b12d020).